### PR TITLE
fix: use internal_service_url over service_url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Unreleased
 
 *
 
+0.3.1 - 2024-03-14
+******************
+
+Added
+=====
+
+* Fixed development server configuration.
+
 0.3.0 – 2024-03-10
 ******************
 Added

--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/utils.py
+++ b/platform_plugin_aspects/utils.py
@@ -84,7 +84,8 @@ def _generate_guest_token(user, course, superset_config, dashboard_uuid, filters
         or None, exception if Superset is missconfigured or cannot generate guest token.
     """
     superset_internal_host = _fix_service_url(
-        superset_config.get("service_url", superset_config.get("internal_service_url"))
+        superset_config.get("internal_service_url")
+        or superset_config.get("service_url")
     )
     superset_username = superset_config.get("username")
     superset_password = superset_config.get("password")


### PR DESCRIPTION
### Description

In production the expected behavior is to call the Superset API via HTTPS, however for local development we can't use the superset host to connect to the API due that `local.edly.io` points to `127.0.0.1` which in a container is in the container port, not the local machine.

This PR fixed the development server by preferring using the `internal_service_url` (`superset:8088`) over the `service_url`. In production, this variable is not included so that it defaults to the `service_url`.

A proper PR in tutor-contrib-aspects is created to align with the changes: https://github.com/openedx/tutor-contrib-aspects/pull/656

Working locally and remote:
![image](https://github.com/openedx/platform-plugin-aspects/assets/33465240/43171f41-2eeb-424d-ac45-a59a79eedd12)

![image](https://github.com/openedx/platform-plugin-aspects/assets/33465240/68456691-0f85-47fa-a55a-eb990776d1ea)
