### PR TITLE
fix: xblock not rendering correctly when no dashboard_uuid is set

### DIFF
--- a/platform_plugin_aspects/static/html/superset.html
+++ b/platform_plugin_aspects/static/html/superset.html
@@ -8,8 +8,8 @@
     {% if exception %}
     <p>{% trans 'Superset is not configured properly. Please contact your system administrator.'%}</p>
     <p>{{exception}}</p>
-    {% elif not dashboard_uuid and not superset_dashboards %}
-    <p>Dashboard UUID is not set. Please set the dashboard UUID in the Studio. {{dashboard_uuid}}</p>
+    {% elif not superset_dashboards %}
+    <p>Dashboard UUID is not set. Please set the dashboard UUID in the Studio.</p>
     {% elif superset_url and superset_token %} {% if xblock_id %}
     <div class="superset-embedded-container" id="superset-embedded-container-{{xblock_id}}"></div>
     {% else %}

--- a/platform_plugin_aspects/tests/test_xblock.py
+++ b/platform_plugin_aspects/tests/test_xblock.py
@@ -69,7 +69,10 @@ class TestRender(TestCase):
         mock_superset_client.assert_called_once()
         html = student_view.content
         self.assertIsNotNone(html)
-        self.assertIn("superset-embedded-container", html)
+        self.assertIn(
+            "Dashboard UUID is not set. Please set the dashboard UUID in the Studio.",
+            html,
+        )
 
     def test_render_student(self):
         """

--- a/platform_plugin_aspects/xblock.py
+++ b/platform_plugin_aspects/xblock.py
@@ -55,6 +55,15 @@ class SupersetXBlock(StudioEditableXBlockMixin, XBlock):
         scope=Scope.settings,
     )
 
+    def dashboards(self):
+        """
+        Returns an array of dashboards configured for this XBlock.
+        """
+        if self.dashboard_uuid:
+            return [{"name": self.display_name, "uuid": self.dashboard_uuid}]
+        else:
+            return []
+
     def render_template(self, template_path, context=None) -> str:
         """
         Render a template with the given context.
@@ -104,7 +113,7 @@ class SupersetXBlock(StudioEditableXBlockMixin, XBlock):
         context = generate_superset_context(
             context=context,
             user=user,
-            dashboards=[{"name": self.display_name, "uuid": self.dashboard_uuid}],
+            dashboards=self.dashboards(),
             filters=self.filters,
         )
         context["xblock_id"] = str(self.scope_ids.usage_id.block_id)

--- a/platform_plugin_aspects/xblock.py
+++ b/platform_plugin_aspects/xblock.py
@@ -57,7 +57,7 @@ class SupersetXBlock(StudioEditableXBlockMixin, XBlock):
 
     def dashboards(self):
         """
-        Returns an array of dashboards configured for this XBlock.
+        Return an array of dashboards configured for this XBlock.
         """
         if self.dashboard_uuid:
             return [{"name": self.display_name, "uuid": self.dashboard_uuid}]


### PR DESCRIPTION
Initial XBlock display (without editing configuration) shows a confusing error:

![image](https://github.com/openedx/platform-plugin-aspects/assets/7556571/6d4c5a42-39a8-430d-b2b3-aa999c38b97a)

This change fixes this by checking to see if the `dashboard_uuid` is set before using it as the `superset_dashboards` context:

![image](https://github.com/openedx/platform-plugin-aspects/assets/7556571/61a69685-b72a-4fec-bd54-7aadbe6c0b57)

And now after editing the XBlock to set `dashboard_uuid = 1d6bf904-f53f-47fd-b1c9-6cd7e284d286` (and refresh..):

![image](https://github.com/openedx/platform-plugin-aspects/assets/7556571/b4428937-2876-46ad-a115-1a1c85454de7)
