### PR TITLE
chore: Use correct name for drf dependency

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,6 +13,6 @@ redis
 requests           # HTTP request library
 edx-django-utils   # Django utilities, we use caching and monitoring
 edx-opaque-keys    # Parsing library for course and usage keys
-django-rest-framework     # REST API framework
+djangorestframework     # REST API framework
 edx-toggles
 XBlock

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -59,14 +59,12 @@ django-crum==0.7.9
     #   -r requirements/base.in
     #   edx-django-utils
     #   edx-toggles
-django-rest-framework==0.1.0
-    # via -r requirements/base.in
 django-waffle==4.1.0
     # via
     #   edx-django-utils
     #   edx-toggles
 djangorestframework==3.15.1
-    # via django-rest-framework
+    # via -r requirements/base.in
 edx-django-utils==5.12.0
     # via
     #   -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -142,8 +142,6 @@ django-crum==0.7.9
     #   edx-toggles
 django-mock-queries==2.2.0
     # via -r requirements/quality.txt
-django-rest-framework==0.1.0
-    # via -r requirements/quality.txt
 django-waffle==4.1.0
     # via
     #   -r requirements/quality.txt
@@ -153,7 +151,6 @@ djangorestframework==3.15.1
     # via
     #   -r requirements/quality.txt
     #   django-mock-queries
-    #   django-rest-framework
 edx-django-utils==5.12.0
     # via
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -52,7 +52,6 @@ certifi==2024.2.2
 cffi==1.16.0
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via
@@ -87,8 +86,6 @@ coverage[toml]==7.4.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==42.0.5
-    # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
 django==4.2.11
@@ -110,8 +107,6 @@ django-crum==0.7.9
     #   edx-toggles
 django-mock-queries==2.2.0
     # via -r requirements/test.txt
-django-rest-framework==0.1.0
-    # via -r requirements/test.txt
 django-waffle==4.1.0
     # via
     #   -r requirements/test.txt
@@ -121,7 +116,6 @@ djangorestframework==3.15.1
     # via
     #   -r requirements/test.txt
     #   django-mock-queries
-    #   django-rest-framework
 doc8==1.1.1
     # via -r requirements/doc.in
 docutils==0.19
@@ -172,16 +166,12 @@ jaraco-context==4.3.0
     # via keyring
 jaraco-functools==4.0.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   sphinx
-keyring==25.0.0
+keyring==25.1.0
     # via twine
 kombu==5.3.6
     # via
@@ -333,8 +323,6 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.1
     # via twine
-secretstorage==3.3.3
-    # via keyring
 simplejson==3.19.2
     # via
     #   -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -109,8 +109,6 @@ django-crum==0.7.9
     #   edx-toggles
 django-mock-queries==2.2.0
     # via -r requirements/test.txt
-django-rest-framework==0.1.0
-    # via -r requirements/test.txt
 django-waffle==4.1.0
     # via
     #   -r requirements/test.txt
@@ -120,7 +118,6 @@ djangorestframework==3.15.1
     # via
     #   -r requirements/test.txt
     #   django-mock-queries
-    #   django-rest-framework
 edx-django-utils==5.12.0
     # via
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -93,8 +93,6 @@ django-crum==0.7.9
     #   edx-toggles
 django-mock-queries==2.2.0
     # via -r requirements/test.in
-django-rest-framework==0.1.0
-    # via -r requirements/base.txt
 django-waffle==4.1.0
     # via
     #   -r requirements/base.txt
@@ -104,7 +102,6 @@ djangorestframework==3.15.1
     # via
     #   -r requirements/base.txt
     #   django-mock-queries
-    #   django-rest-framework
 edx-django-utils==5.12.0
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
Using django-rest-framework causes spurious Dependabot alerts. It's just an alias for djangorestframework so we should be using that instead.

