### PR TITLE
build: Fix extract_translations when run in openedx-translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,8 @@ selfcheck: ## check that the Makefile is well-formed
 
 extract_translations: ## extract strings to be translated, outputting .mo files
 	rm -rf docs/_build
-	cd platform_plugin_aspects && i18n_tool extract --no-segment
+	cd platform_plugin_aspects && django-admin makemessages -l en -v1 -d django
+	cd platform_plugin_aspects && django-admin makemessages -l en -v1 -d djangojs
 
 compile_translations: ## compile translation files, outputting .po files for each supported language
 	cd platform_plugin_aspects && i18n_tool generate

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -75,15 +75,15 @@ edx-toggles==5.2.0
     # via -r requirements/base.in
 fs==2.4.16
     # via xblock
-idna==3.6
+idna==3.7
     # via requests
 jinja2==3.1.3
     # via code-annotations
-kombu==5.3.6
+kombu==5.3.7
     # via celery
 lxml==5.2.1
     # via xblock
-mako==1.3.2
+mako==1.3.3
     # via xblock
 markupsafe==2.1.5
     # via
@@ -96,7 +96,7 @@ oauthlib==3.2.2
     # via requests-oauthlib
 openedx-atlas==0.6.0
     # via -r requirements/base.in
-openedx-filters==1.6.0
+openedx-filters==1.8.1
     # via -r requirements/base.in
 pbr==6.0.0
     # via stevedore

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,7 +12,7 @@ colorama==0.4.6
     # via tox
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.3
+filelock==3.13.4
     # via
     #   tox
     #   virtualenv

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -155,7 +155,7 @@ edx-django-utils==5.12.0
     # via
     #   -r requirements/quality.txt
     #   edx-toggles
-edx-i18n-tools==1.3.0
+edx-i18n-tools==1.5.0
     # via -r requirements/dev.in
 edx-lint==5.3.6
     # via -r requirements/quality.txt
@@ -167,7 +167,7 @@ exceptiongroup==1.2.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-filelock==3.13.3
+filelock==3.13.4
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -176,7 +176,7 @@ fs==2.4.16
     # via
     #   -r requirements/quality.txt
     #   xblock
-idna==3.6
+idna==3.7
     # via
     #   -r requirements/quality.txt
     #   requests
@@ -198,7 +198,7 @@ jinja2==3.1.3
     #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
-kombu==5.3.6
+kombu==5.3.7
     # via
     #   -r requirements/quality.txt
     #   celery
@@ -207,7 +207,7 @@ lxml==5.2.1
     #   -r requirements/quality.txt
     #   edx-i18n-tools
     #   xblock
-mako==1.3.2
+mako==1.3.3
     # via
     #   -r requirements/quality.txt
     #   xblock
@@ -239,7 +239,7 @@ oauthlib==3.2.2
     #   requests-oauthlib
 openedx-atlas==0.6.0
     # via -r requirements/quality.txt
-openedx-filters==1.6.0
+openedx-filters==1.8.1
     # via -r requirements/quality.txt
 packaging==24.0
     # via
@@ -251,7 +251,7 @@ packaging==24.0
     #   pyproject-api
     #   pytest
     #   tox
-path==16.12.1
+path==16.14.0
     # via edx-i18n-tools
 pathspec==0.12.1
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -54,7 +54,6 @@ certifi==2024.2.2
 cffi==1.16.0
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via
@@ -89,8 +88,6 @@ coverage[toml]==7.4.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==42.0.5
-    # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
 django==4.2.11
@@ -146,7 +143,7 @@ fs==2.4.16
     # via
     #   -r requirements/test.txt
     #   xblock
-idna==3.6
+idna==3.7
     # via
     #   -r requirements/test.txt
     #   requests
@@ -171,10 +168,6 @@ jaraco-context==5.3.0
     # via keyring
 jaraco-functools==4.0.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.3
     # via
     #   -r requirements/test.txt
@@ -182,7 +175,7 @@ jinja2==3.1.3
     #   sphinx
 keyring==25.1.0
     # via twine
-kombu==5.3.6
+kombu==5.3.7
     # via
     #   -r requirements/test.txt
     #   celery
@@ -190,7 +183,7 @@ lxml==5.2.1
     # via
     #   -r requirements/test.txt
     #   xblock
-mako==1.3.2
+mako==1.3.3
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -224,7 +217,7 @@ oauthlib==3.2.2
     #   requests-oauthlib
 openedx-atlas==0.6.0
     # via -r requirements/test.txt
-openedx-filters==1.6.0
+openedx-filters==1.8.1
     # via -r requirements/test.txt
 packaging==24.0
     # via
@@ -332,8 +325,6 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.1
     # via twine
-secretstorage==3.3.3
-    # via keyring
 simplejson==3.19.2
     # via
     #   -r requirements/test.txt

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.43.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0
     # via -r requirements/pip.in
-setuptools==69.2.0
+setuptools==69.4.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -136,7 +136,7 @@ fs==2.4.16
     # via
     #   -r requirements/test.txt
     #   xblock
-idna==3.6
+idna==3.7
     # via
     #   -r requirements/test.txt
     #   requests
@@ -152,7 +152,7 @@ jinja2==3.1.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
-kombu==5.3.6
+kombu==5.3.7
     # via
     #   -r requirements/test.txt
     #   celery
@@ -160,7 +160,7 @@ lxml==5.2.1
     # via
     #   -r requirements/test.txt
     #   xblock
-mako==1.3.2
+mako==1.3.3
     # via
     #   -r requirements/test.txt
     #   xblock
@@ -188,7 +188,7 @@ oauthlib==3.2.2
     #   requests-oauthlib
 openedx-atlas==0.6.0
     # via -r requirements/test.txt
-openedx-filters==1.6.0
+openedx-filters==1.8.1
     # via -r requirements/test.txt
 packaging==24.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -116,7 +116,7 @@ fs==2.4.16
     # via
     #   -r requirements/base.txt
     #   xblock
-idna==3.6
+idna==3.7
     # via
     #   -r requirements/base.txt
     #   requests
@@ -126,7 +126,7 @@ jinja2==3.1.3
     # via
     #   -r requirements/base.txt
     #   code-annotations
-kombu==5.3.6
+kombu==5.3.7
     # via
     #   -r requirements/base.txt
     #   celery
@@ -134,7 +134,7 @@ lxml==5.2.1
     # via
     #   -r requirements/base.txt
     #   xblock
-mako==1.3.2
+mako==1.3.3
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -156,7 +156,7 @@ oauthlib==3.2.2
     #   requests-oauthlib
 openedx-atlas==0.6.0
     # via -r requirements/base.txt
-openedx-filters==1.6.0
+openedx-filters==1.8.1
     # via -r requirements/base.txt
 packaging==24.0
     # via pytest


### PR DESCRIPTION
A variety of errors happen in openedx-translations when trying to use i18n_tools to extract. Since we don't seem to need any of that functionality, we can just use the django commands. This was successfully tested in my fork.