### PR TITLE
fix: Normalize localized asset UUIDs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Unreleased
 
 *
 
+0.7.3 - 2024-04-30
+******************
+
+Fixed
+=====
+
+* Fixed UUID generation for localized Superset assets, which caused embedded
+  dashboards to fail to load when localized.
+
 0.7.2 - 2024-04-19
 ******************
 

--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/extensions/filters.py
+++ b/platform_plugin_aspects/extensions/filters.py
@@ -37,7 +37,9 @@ class AddSupersetTab(PipelineStep):
             get_model("user_preference").get_value(user, "pref-lang") or "en"
         )
         formatted_language = user_language.replace("-", "_")
-        if formatted_language not in [loc.lower().replace("-", "_") for loc in settings.SUPERSET_DASHBOARD_LOCALES]:
+        if formatted_language not in [
+            loc.lower().replace("-", "_") for loc in settings.SUPERSET_DASHBOARD_LOCALES
+        ]:
             formatted_language = "en"
 
         context["course_id"] = course.id

--- a/platform_plugin_aspects/extensions/filters.py
+++ b/platform_plugin_aspects/extensions/filters.py
@@ -34,11 +34,11 @@ class AddSupersetTab(PipelineStep):
         user = get_current_user()
 
         user_language = (
-            get_model("user_preference").get_value(user, "pref-lang") or "en_US"
+            get_model("user_preference").get_value(user, "pref-lang") or "en"
         )
         formatted_language = user_language.replace("-", "_")
-        if formatted_language not in settings.SUPERSET_DASHBOARD_LOCALES:
-            formatted_language = "en_US"
+        if formatted_language not in [loc.lower().replace("-", "_") for loc in settings.SUPERSET_DASHBOARD_LOCALES]:
+            formatted_language = "en"
 
         context["course_id"] = course.id
         context = generate_superset_context(

--- a/platform_plugin_aspects/extensions/filters.py
+++ b/platform_plugin_aspects/extensions/filters.py
@@ -36,7 +36,7 @@ class AddSupersetTab(PipelineStep):
         user_language = (
             get_model("user_preference").get_value(user, "pref-lang") or "en"
         )
-        formatted_language = user_language.replace("-", "_")
+        formatted_language = user_language.lower().replace("-", "_")
         if formatted_language not in [
             loc.lower().replace("-", "_") for loc in settings.SUPERSET_DASHBOARD_LOCALES
         ]:

--- a/platform_plugin_aspects/settings/common.py
+++ b/platform_plugin_aspects/settings/common.py
@@ -29,7 +29,7 @@ def plugin_settings(settings):
         },
     ]
     settings.SUPERSET_EXTRA_FILTERS_FORMAT = []
-    settings.SUPERSET_DASHBOARD_LOCALES = ["en_US"]
+    settings.SUPERSET_DASHBOARD_LOCALES = ["en"]
     settings.EVENT_SINK_CLICKHOUSE_BACKEND_CONFIG = {
         # URL to a running ClickHouse server's HTTP interface. ex: https://foo.openedx.org:8443/ or
         # http://foo.openedx.org:8123/ . Note that we only support the ClickHouse HTTP interface

--- a/platform_plugin_aspects/utils.py
+++ b/platform_plugin_aspects/utils.py
@@ -268,4 +268,5 @@ def get_localized_uuid(base_uuid, language):
     """
     base_uuid = uuid.UUID(base_uuid)
     base_namespace = uuid.uuid5(base_uuid, "superset")
-    return str(uuid.uuid5(base_namespace, language))
+    normalized_language = language.lower().replace("-", "_")
+    return  str(uuid.uuid5(base_namespace, normalized_language))

--- a/platform_plugin_aspects/utils.py
+++ b/platform_plugin_aspects/utils.py
@@ -269,4 +269,4 @@ def get_localized_uuid(base_uuid, language):
     base_uuid = uuid.UUID(base_uuid)
     base_namespace = uuid.uuid5(base_uuid, "superset")
     normalized_language = language.lower().replace("-", "_")
-    return  str(uuid.uuid5(base_namespace, normalized_language))
+    return str(uuid.uuid5(base_namespace, normalized_language))


### PR DESCRIPTION
This fixes mismatches between this plugin and the assets generated in Aspects that cause translated dashboards to not embed properly. There is a matching PR in tutor-contrib-aspects that is needed to complete this fix.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
