### PR TITLE
refactor: Update course dashboard slug to match tutor plugin

### DIFF
--- a/platform_plugin_aspects/settings/common.py
+++ b/platform_plugin_aspects/settings/common.py
@@ -29,7 +29,7 @@ def plugin_settings(settings):
     settings.ASPECTS_INSTRUCTOR_DASHBOARDS = [
         {
             "name": _("Course Dashboard"),
-            "slug": "course-dashboard-v1",
+            "slug": "course-dashboard",
             "uuid": "c0e64194-33d1-4d5a-8c10-4f51530c5ee9",
             "allow_translations": True,
         },


### PR DESCRIPTION
The dashboard name changed, so did the slug. Technically this slug isn't used from this location as the config is overwritten in tutor-contrib-aspects, but I just want to keep them in sync.