### PR TITLE
fix: Fix xblock.utils imports for pre-quince releases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 **********
 
+0.9.1 - 2024-05-08
+******************
+
+Fixes
+=====
+
+* Fix an ImportError in the Aspects Xblock on pre-Quince releases
+
+
 0.9.0 - 2024-05-06
 ******************
 

--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/xblock.py
+++ b/platform_plugin_aspects/xblock.py
@@ -16,7 +16,7 @@ from xblock.fields import List, Scope, String
 
 # These moved from xblockutils to xblock in Quince, these can be removed
 # when we stop supporting earlier versions.
-try:
+try:  # pragma: no-cover
     from xblock.utils.resources import ResourceLoader
     from xblock.utils.studio_editable import StudioEditableXBlockMixin
 except ImportError:

--- a/platform_plugin_aspects/xblock.py
+++ b/platform_plugin_aspects/xblock.py
@@ -13,8 +13,15 @@ from webob import Response
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
 from xblock.fields import List, Scope, String
-from xblock.utils.resources import ResourceLoader
-from xblock.utils.studio_editable import StudioEditableXBlockMixin
+
+# These moved from xblockutils to xblock in Quince, these can be removed
+# when we stop supporting earlier versions.
+try:
+    from xblock.utils.resources import ResourceLoader
+    from xblock.utils.studio_editable import StudioEditableXBlockMixin
+except ImportError:
+    from xblockutils.resources import ResourceLoader
+    from xblockutils.studio_editable import StudioEditableXBlockMixin
 
 from .utils import (
     DEFAULT_FILTERS_FORMAT,


### PR DESCRIPTION
**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
