### PR TITLE
fix: Turn off superset guest token caching

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 **********
 
+0.9.2 - 2024-05-08
+******************
+
+Fixes
+=====
+
+* Remove caching of Superset guest token to fix various display errors and token refresh edge cases.
+
 0.9.1 - 2024-05-08
 ******************
 

--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/views.py
+++ b/platform_plugin_aspects/views.py
@@ -6,8 +6,6 @@ from collections import namedtuple
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import permissions
@@ -104,7 +102,6 @@ class SupersetView(GenericAPIView):
 
         return course_key
 
-    @method_decorator(cache_page(60 * 5))
     def get(self, request, *args, **kwargs):
         """
         Return a guest token for accessing the Superset API.


### PR DESCRIPTION
This may be temporary and require further caching, but right now I think it may be a premature optimization and is causing a variety of bugs.

Closes: https://github.com/openedx/tutor-contrib-aspects/issues/759


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
