### PR TITLE
fix: serialize datetime objects as strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 **********
 
+0.9.4 - 2024-05-16
+******************
+
+Fixes
+=====
+
+* Allow to serialize dates as strings in JSON.
+
 0.9.3 - 2024-05-15
 ******************
 

--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "0.9.3"
+__version__ = "0.9.4"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/extensions/filters.py
+++ b/platform_plugin_aspects/extensions/filters.py
@@ -71,7 +71,6 @@ class AddSupersetTab(PipelineStep):
             "show_dashboard_link": show_dashboard_link,
         }
 
-        print(section_data)
         context["sections"].append(section_data)
         return {
             "context": context,

--- a/platform_plugin_aspects/management/commands/load_test_tracking_events.py
+++ b/platform_plugin_aspects/management/commands/load_test_tracking_events.py
@@ -158,7 +158,6 @@ class LoadTest:
         output = io.StringIO()
         writer = csv.writer(output)
         writer.writerow((self.run_id, event_type, json.dumps(extra)))
-        print(output.getvalue().encode("utf-8"))
 
         response = requests.post(
             url=self.ch_url,

--- a/platform_plugin_aspects/management/commands/monitor_load_test_tracking.py
+++ b/platform_plugin_aspects/management/commands/monitor_load_test_tracking.py
@@ -145,6 +145,7 @@ class Monitor:
             lag = None
 
             current_stats = {"clickhouse": self.get_clickhouse_stats()}
+            lag = -1
             if collect_redis_bus:
                 current_stats["redis_bus"] = self.get_redis_bus_stats()
                 lag = current_stats["redis_bus"]["lag"]

--- a/platform_plugin_aspects/sinks/tests/test_serializers.py
+++ b/platform_plugin_aspects/sinks/tests/test_serializers.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
@@ -6,6 +7,7 @@ from django.test import TestCase
 from platform_plugin_aspects.sinks.serializers import (
     BaseSinkSerializer,
     CourseOverviewSerializer,
+    DateTimeJSONEncoder,
 )
 from test_utils.helpers import course_key_factory
 
@@ -60,7 +62,7 @@ class TestCourseOverviewSerializer(TestCase):
         """
         expected_tags = ["TAX1=tag1", "TAX2=tag2"]
         json_fields = {
-            "advertised_start": "2018-01-01T00:00:00Z",
+            "advertised_start": datetime.now(),
             "announcement": "announcement",
             "lowest_passing_grade": 0.0,
             "invitation_only": "invitation_only",
@@ -80,7 +82,8 @@ class TestCourseOverviewSerializer(TestCase):
         mock_get_tags.return_value = expected_tags
 
         self.assertEqual(
-            self.serializer.get_course_data_json(mock_overview), json.dumps(json_fields)
+            self.serializer.get_course_data_json(mock_overview),
+            json.dumps(json_fields, cls=DateTimeJSONEncoder),
         )
         mock_get_tags.assert_called_once_with(mock_overview.id)
 

--- a/platform_plugin_aspects/tests/test_xblock.py
+++ b/platform_plugin_aspects/tests/test_xblock.py
@@ -103,8 +103,10 @@ class TestRender(TestCase):
         for resource in student_view.resources:
             if resource.kind == "url":
                 url_resource = resource
-        self.assertIsNotNone(url_resource, "No 'url' resource found in fragment")
-        self.assertIn("eo/text.js", url_resource.data)
+                self.assertIsNotNone(
+                    url_resource, "No 'url' resource found in fragment"
+                )
+                self.assertIn("eo/text.js", url_resource.data)
         mock_get_language.assert_called_once()
         mock_resource_exists.assert_called_once()
 


### PR DESCRIPTION
### Description

This PR fixes an issue when serializing as JSON the course data where some attributes were dates cannot be encoded by default. We use the code from `event-tracking` to allow the serialization of datetime objects as JSON.
