### PR TITLE
fix: User profile not found on account creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 **********
 
+0.9.5 - 2024-05-24
+******************
+
+Fixes
+=====
+
+* UserProfile sink now runs after the transaction is committed, preventing UserProfileNotFound errors and creation of rows in ClickHouse that don't exist in MySQL in the case of a rollback.
+
+
 0.9.4 - 2024-05-16
 ******************
 

--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/xblock.py
+++ b/platform_plugin_aspects/xblock.py
@@ -16,10 +16,10 @@ from xblock.fields import List, Scope, String
 
 # These moved from xblockutils to xblock in Quince, these can be removed
 # when we stop supporting earlier versions.
-try:  # pragma: no-cover
+try:  # pragma: no cover
     from xblock.utils.resources import ResourceLoader
     from xblock.utils.studio_editable import StudioEditableXBlockMixin
-except ImportError:
+except ImportError:  # pragma: no cover
     from xblockutils.resources import ResourceLoader
     from xblockutils.studio_editable import StudioEditableXBlockMixin
 


### PR DESCRIPTION
Sometimes the user profile sink would get run before the transaction creating the target row was committed in the LMS. This led to UserProfileNotFound errors and the data not making its way to ClickHouse. This delays creating the task until the transaction is committed.

Closes: #54 

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Fixup commits are squashed away

