### PR TITLE
fix: Fix course-overviews sink not ordering blocks correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 **********
 
+0.9.6 - 2024-06-07
+******************
+
+Fixes
+=====
+
+* The CourseOutline sink was not always ordering blocks correctly, leading to issues with blocks appearing in the wrong sections/subsection.
+
+
 0.9.5 - 2024-05-24
 ******************
 

--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "0.9.5"
+__version__ = "0.9.6"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/tests/test_utils.py
+++ b/platform_plugin_aspects/tests/test_utils.py
@@ -262,9 +262,9 @@ class TestUtils(TestCase):
         mock_tag22 = mock_tag(mock_taxonomy2, "tag2.2")
         mock_get_object_tags.return_value = [mock_tag13, mock_tag21, mock_tag22]
 
-        course_tags = get_tags_for_block(course[0].location)
+        course_tags = get_tags_for_block(course.location)
         assert course_tags == {
             "Taxonomy One": ["tag1.3", "tag1.2", "tag1.1"],
             "Taxonomy Two": ["tag2.1", "tag2.2"],
         }
-        mock_get_object_tags.assert_called_once_with(course[0].location)
+        mock_get_object_tags.assert_called_once_with(course.location)


### PR DESCRIPTION
We've been using Modulestore's get_items, but even though it's often correct the ordering isn't guaranteed. The new method walks the course tree itself, then adds in the detached models separately.

Potential concerns:

This was already a pretty heavy operation, calling into Modulestore twice to walk all of the blocks may not be performant enough or cause issues in the LMS/CMS. It may be preferable to ignore detached blocks if we are not currently using them, but I wanted to preserve parity with what we've been doing unless/until there is an actual problem.

Closes: #61 


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [ ] Fixup commits are squashed away
- [x] Unit tests added/updated
- [ ] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
