### PR TITLE
Fix course block CSV ordering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 **********
 
+0.9.7 - 2024-06-14
+******************
+
+Fixes
+=====
+
+* 0.9.6 introduced a bug in the CourseOverview sink that caused block sink to fail to import to ClickHouse, this fixes it.
+
+
 0.9.6 - 2024-06-07
 ******************
 

--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/sinks/course_overview_sink.py
+++ b/platform_plugin_aspects/sinks/course_overview_sink.py
@@ -184,6 +184,9 @@ class XBlockSink(ModelBaseSink):
             "location": str(XBlockSink.strip_branch_and_version(item.location)),
             "display_name": item.display_name_with_default.replace("'", "'"),
             "xblock_data_json": json_data,
+            # We need to add this here so the key will be in the right place
+            # in the generated csv
+            "order": -1,
             "edited_on": str(getattr(item, "edited_on", "")),
             "dump_id": dump_id,
             "time_last_dumped": time_last_dumped,

--- a/test_utils/helpers.py
+++ b/test_utils/helpers.py
@@ -379,7 +379,10 @@ def check_block_csv_matcher(course):
                 assert block_json_data["course"] == csv_json["course"]
                 assert block_json_data["run"] == csv_json["run"]
                 assert block_json_data["block_type"] == csv_json["block_type"]
+
+                # The order sent here should match our block order, but starts at 1
                 i += 1
+                assert row[5] == str(i)
         except AssertionError as e:
             return False, f"Mismatch in row {i}: {e}"
         return True, ""


### PR DESCRIPTION
The last change caused the "order" key to move to a new place in the CSV, breaking import ordering. This fixes that and adds a test for the order key.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Unit tests added/updated
