### PR TITLE
feat: add course enrollment sink

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 **********
 
+0.10.0 - 2024-06-17
+*******************
+
+Added
+=====
+
+* A sink for the course enrollment model.
+
 0.9.7 - 2024-06-14
 ******************
 

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,8 @@ Available Sinks
   model and stores the user profile data in ClickHouse.
 - `UserRetirementSink` - Listen for the `USER_RETIRE_LMS_MISC` Django signal and
   remove the user PII information from ClickHouse.
+- `CourseEnrollmentSink` - Listen for the `ENROLL_STATUS_CHANGE` event and stores
+  the course enrollment data.
 
 Commands
 ========

--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "0.9.7"
+__version__ = "0.10.0"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/apps.py
+++ b/platform_plugin_aspects/apps.py
@@ -49,7 +49,18 @@ class PlatformPluginAspectsConfig(AppConfig):
                         PluginSignals.SIGNAL_PATH: "xmodule.modulestore.django.COURSE_PUBLISHED",
                     }
                 ],
-            }
+            },
+            "lms.djangoapp": {
+                # List of all plugin Signal receivers for this app and project type.
+                PluginSignals.RECEIVERS: [
+                    {
+                        # The name of the app's signal receiver function.
+                        PluginSignals.RECEIVER_FUNC_NAME: "receive_course_enrollment_changed",
+                        # The full path to the module where the signal is defined.
+                        PluginSignals.SIGNAL_PATH: "common.djangoapps.student.signals.signals.ENROLL_STATUS_CHANGE",
+                    }
+                ],
+            },
         },
     }
 

--- a/platform_plugin_aspects/settings/common.py
+++ b/platform_plugin_aspects/settings/common.py
@@ -82,6 +82,10 @@ def plugin_settings(settings):
             "module": "openedx.core.djangoapps.external_user_ids.models",
             "model": "ExternalId",
         },
+        "course_enrollment": {
+            "module": "common.djangoapps.student.models",
+            "model": "CourseEnrollment",
+        },
         "custom_course_edx": {
             "module": "lms.djangoapps.ccx.models",
             "model": "CustomCourseForEdX",

--- a/platform_plugin_aspects/signals.py
+++ b/platform_plugin_aspects/signals.py
@@ -39,7 +39,7 @@ def receive_course_enrollment_changed(  # pylint: disable=unused-argument  # pra
     sender, **kwargs
 ):
     """
-    Receives ENROLL_STATUS_CHANGE
+    Receives ENROLL_STATUS_CHANGE signal and queues the dump job.
     """
     from platform_plugin_aspects.tasks import (  # pylint: disable=import-outside-toplevel
         dump_data_to_clickhouse,

--- a/platform_plugin_aspects/sinks/__init__.py
+++ b/platform_plugin_aspects/sinks/__init__.py
@@ -3,6 +3,7 @@ This module contains the sinks for the platform plugin aspects.
 """
 
 from .base_sink import BaseSink, ModelBaseSink
+from .course_enrollment_sink import CourseEnrollmentSink
 from .course_overview_sink import CourseOverviewSink, XBlockSink
 from .external_id_sink import ExternalIdSink
 from .user_profile_sink import UserProfileSink

--- a/platform_plugin_aspects/sinks/base_sink.py
+++ b/platform_plugin_aspects/sinks/base_sink.py
@@ -271,7 +271,7 @@ class ModelBaseSink(BaseSink):
                 writer.writerow(node.values())
         else:
             writer.writerow(serialized_item.values())
-        print("ClickHouse CSV output", output.getvalue().encode("utf-8"))
+
         request = requests.Request(
             "POST",
             self.ch_url,

--- a/platform_plugin_aspects/sinks/base_sink.py
+++ b/platform_plugin_aspects/sinks/base_sink.py
@@ -271,7 +271,7 @@ class ModelBaseSink(BaseSink):
                 writer.writerow(node.values())
         else:
             writer.writerow(serialized_item.values())
-
+        print("ClickHouse CSV output", output.getvalue().encode("utf-8"))
         request = requests.Request(
             "POST",
             self.ch_url,

--- a/platform_plugin_aspects/sinks/course_enrollment_sink.py
+++ b/platform_plugin_aspects/sinks/course_enrollment_sink.py
@@ -1,0 +1,20 @@
+"""User profile sink"""
+
+from platform_plugin_aspects.sinks.base_sink import ModelBaseSink
+from platform_plugin_aspects.sinks.serializers import CourseEnrollmentSerializer
+
+
+class CourseEnrollmentSink(ModelBaseSink):  # pylint: disable=abstract-method
+    """
+    Sink for user CourseEnrollment model
+    """
+
+    model = "course_enrollment"
+    unique_key = "id"
+    clickhouse_table_name = "course_enrollment"
+    timestamp_field = "time_last_dumped"
+    name = "Course Enrollment"
+    serializer_class = CourseEnrollmentSerializer
+
+    def get_queryset(self, start_pk=None):
+        return super().get_queryset(start_pk).select_related("user")

--- a/platform_plugin_aspects/sinks/serializers.py
+++ b/platform_plugin_aspects/sinks/serializers.py
@@ -179,3 +179,30 @@ class CourseOverviewSerializer(BaseSinkSerializer, serializers.ModelSerializer):
     def get_course_key(self, overview):
         """Return the course key as a string."""
         return str(overview.id)
+
+
+class CourseEnrollmentSerializer(BaseSinkSerializer, serializers.ModelSerializer):
+    """Serializer for the Course Enrollment model."""
+
+    course_key = serializers.SerializerMethodField()
+    username = serializers.CharField(source="user.username")
+
+    class Meta:
+        """Meta class for the CourseEnrollmentSerializer"""
+
+        model = get_model("course_enrollment")
+        fields = [
+            "id",
+            "course_key",
+            "created",
+            "is_active",
+            "mode",
+            "username",
+            "user_id",
+            "dump_id",
+            "time_last_dumped",
+        ]
+
+    def get_course_key(self, obj):
+        """Return the course key as a string."""
+        return str(obj.course_id)

--- a/platform_plugin_aspects/sinks/tests/test_course_enrollment_sink.py
+++ b/platform_plugin_aspects/sinks/tests/test_course_enrollment_sink.py
@@ -1,0 +1,20 @@
+"""
+Test the course enrollment sink module.
+"""
+
+from unittest.mock import patch
+
+from platform_plugin_aspects.sinks import CourseEnrollmentSink
+
+
+@patch("platform_plugin_aspects.sinks.ModelBaseSink.get_queryset")
+def test_get_queryset(mock_get_queryset):
+    """
+    Test the get_queryset method.
+    """
+    sink = CourseEnrollmentSink(None, None)
+
+    sink.get_queryset()
+
+    mock_get_queryset.assert_called_once_with(None)
+    mock_get_queryset.return_value.select_related.assert_called_once_with("user")


### PR DESCRIPTION
### Description

This PR creates a sink for the Course Enrollment mode. It uses the `ENROLL_STATUS_CHANGE` signal to listen for changes in enrollments.

### Testing instructions

1. Check out this branch on your local repository.
2. Run Aspects migrations to create the necessary table.
3. Enable the course enrollment sink waffle flag `event_sink_clickhouse.course_enrollment.enabled`.
4. Enroll/unenroll in a course via the courseware page or in the instructor dashboard.
5. Verify a record is stored for the enrollment.
6. Verify the `dump_data_to_clickhouse` can dump old data.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
