### PR TITLE
chore: update Django to 4.2.14 for Redwood - Security Patch

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,7 +45,7 @@ click-repl==0.3.0
     # via celery
 code-annotations==1.8.0
     # via edx-toggles
-django==4.2.11
+django==4.2.14
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -123,7 +123,7 @@ distlib==0.3.8
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==4.2.11
+django==4.2.14
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -94,7 +94,7 @@ cryptography==42.0.6
     # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
-django==4.2.11
+django==4.2.14
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -91,7 +91,7 @@ ddt==1.7.2
     # via -r requirements/test.txt
 dill==0.3.8
     # via pylint
-django==4.2.11
+django==4.2.14
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
See: https://github.com/openedx/wg-build-test-release/issues/383