### PR TITLE
chore: Change tested Python version to 3.11 & 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: ['3.8', '3.11']
+        python-version: ['3.11','3.12']
         toxenv: [quality, docs, pii_check, django42]
     permissions:
       # Gives the action the necessary permissions for publishing new
@@ -45,7 +45,7 @@ jobs:
       run: tox
 
     - name: Run coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv == 'django42'
+      if: matrix.python-version == '3.11' && matrix.toxenv == 'django42'
       uses: py-cov-action/python-coverage-comment-action@v3
       with:
         GITHUB_TOKEN: ${{ github.token }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,311}-django{42}
+envlist = py{311,312}-django{42}
 
 [doc8]
 ; D001 = Line too long


### PR DESCRIPTION
From 3.8 and 3.11.

edx-platform has moved to 3.11, we no longer need to support 3.8 and some requirements we have are starting to require 3.9+. See: https://github.com/openedx/platform-plugin-aspects/pull/71

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
