### PR TITLE
fix: delay loading of unfocused dashboards

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 **********
 
+0.11.1 - 2024-09-06
+*******************
+
+Fixes
+=====
+
+* delay loading of unfocused dashboards in LMS.
+
 0.11.0 - 2024-09-04
 *******************
 

--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/static/js/embed_dashboard.js
+++ b/platform_plugin_aspects/static/js/embed_dashboard.js
@@ -43,9 +43,7 @@ async function fetchGuestToken() {
   return data.guestToken;
 }
 
-function embedDashboard(dashboard_uuid, superset_url, xblock_id) {
-  xblock_id = xblock_id || "";
-
+function _embedDashboard(dashboard_uuid, superset_url, xblock_id){
   window.supersetEmbeddedSdk
     .embedDashboard({
       id: dashboard_uuid, // given by the Superset embedding UI
@@ -70,10 +68,26 @@ function embedDashboard(dashboard_uuid, superset_url, xblock_id) {
       when the dashboard is loaded
       */
     });
+}
+
+function embedDashboard(dashboard, superset_url, xblock_id, index) {
+  xblock_id = xblock_id || "";
+  let radio = document.querySelector(`#tab-${index+1}`)
+  if (index == 0){
+    dashboard.loaded = true;
+    _embedDashboard(dashboard.uuid, superset_url, xblock_id)
+  }
+  radio.addEventListener("change", () => {
+    if (dashboard.loaded){
+      return
+    }
+    dashboard.loaded = true;
+    _embedDashboard(dashboard.uuid, superset_url, xblock_id)
+  });
 };
 
 if (window.superset_dashboards !== undefined) {
-  window.superset_dashboards.forEach(function(dashboard) {
-    embedDashboard(dashboard.uuid, window.superset_url, dashboard.uuid);
+  window.superset_dashboards.forEach(function(dashboard, i) {
+    embedDashboard(dashboard, window.superset_url, dashboard.uuid, i);
   });
 }

--- a/platform_plugin_aspects/static/js/superset.js
+++ b/platform_plugin_aspects/static/js/superset.js
@@ -8,7 +8,7 @@ function SupersetXBlock(runtime, element, context) {
   window.from_xblock = true;
 
   function initSuperset(supersetEmbeddedSdk) {
-    embedDashboard(dashboard_uuid, superset_url, xblock_id);
+    _embedDashboard(dashboard_uuid, superset_url, xblock_id);
   }
 
   if (typeof require === "function") {


### PR DESCRIPTION
### Description

This PR delays the loading of unfocused dashboards.

https://github.com/user-attachments/assets/0080ab4b-abba-4565-b99f-7bd353f3f034

Closes: https://github.com/openedx/tutor-contrib-aspects/issues/797

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
