### PR TITLE
fix: Event sink errors when enabled models are missing

### DIFF
--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "0.11.2"
+__version__ = "0.11.3"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/sinks/tests/test_base_sink.py
+++ b/platform_plugin_aspects/sinks/tests/test_base_sink.py
@@ -270,8 +270,9 @@ class TestModelBaseSink(TestCase):
         mock_waffle_flag_is_enabled.return_value = False
         self.assertEqual(self.child_sink.__class__.is_enabled(), False)
 
+    @patch("platform_plugin_aspects.sinks.base_sink.get_model")
     @patch("platform_plugin_aspects.sinks.base_sink.WaffleFlag.is_enabled")
-    def test_is_enabled_waffle(self, mock_waffle_flag_is_enabled):
+    def test_is_enabled_waffle(self, mock_waffle_flag_is_enabled, mock_get_model):
         """
         Test that is_enable() returns the correct data.
         """
@@ -279,7 +280,8 @@ class TestModelBaseSink(TestCase):
         self.assertEqual(self.child_sink.__class__.is_enabled(), True)
 
     @override_settings(EVENT_SINK_CLICKHOUSE_CHILD_MODEL_ENABLED=True)
-    def test_is_enabled(self):
+    @patch("platform_plugin_aspects.sinks.base_sink.get_model")
+    def test_is_enabled(self, mock_get_model):
         """
         Test that is_enable() returns the correct data.
         """

--- a/platform_plugin_aspects/sinks/tests/test_course_overview_sink.py
+++ b/platform_plugin_aspects/sinks/tests/test_course_overview_sink.py
@@ -34,6 +34,7 @@ from test_utils.helpers import (
     registry=OrderedRegistry
 )
 @override_settings(EVENT_SINK_CLICKHOUSE_COURSE_OVERVIEW_ENABLED=True)
+@patch("platform_plugin_aspects.sinks.base_sink.get_model")
 @patch("platform_plugin_aspects.sinks.course_overview_sink.get_tags_for_block")
 @patch("platform_plugin_aspects.sinks.CourseOverviewSink.serialize_item")
 @patch("platform_plugin_aspects.sinks.CourseOverviewSink.get_model")
@@ -47,6 +48,7 @@ def test_course_publish_success(
     mock_overview,
     mock_serialize_item,
     mock_get_tags,
+    mock_get_model,
 ):
     """
     Test of a successful end-to-end run.
@@ -110,13 +112,14 @@ def test_course_publish_success(
 @responses.activate(  # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
     registry=OrderedRegistry
 )
+@patch("platform_plugin_aspects.sinks.base_sink.get_model")
 @patch("platform_plugin_aspects.sinks.CourseOverviewSink.serialize_item")
 @patch("platform_plugin_aspects.sinks.CourseOverviewSink.get_model")
 @patch("platform_plugin_aspects.sinks.course_overview_sink.get_detached_xblock_types")
 @patch("platform_plugin_aspects.sinks.course_overview_sink.get_modulestore")
 # pytest:disable=unused-argument
 def test_course_publish_clickhouse_error(
-    mock_modulestore, mock_detached, mock_overview, mock_serialize_item, caplog
+    mock_modulestore, mock_detached, mock_overview, mock_serialize_item, mock_get_model, caplog
 ):
     """
     Test the case where a ClickHouse POST fails.

--- a/platform_plugin_aspects/sinks/tests/test_course_overview_sink.py
+++ b/platform_plugin_aspects/sinks/tests/test_course_overview_sink.py
@@ -119,7 +119,12 @@ def test_course_publish_success(
 @patch("platform_plugin_aspects.sinks.course_overview_sink.get_modulestore")
 # pytest:disable=unused-argument
 def test_course_publish_clickhouse_error(
-    mock_modulestore, mock_detached, mock_overview, mock_serialize_item, mock_get_model, caplog
+    mock_modulestore,
+    mock_detached,
+    mock_overview,
+    mock_serialize_item,
+    mock_get_model,
+    caplog,
 ):
     """
     Test the case where a ClickHouse POST fails.


### PR DESCRIPTION
When event sinks are enabled in the config or waffle flag, but the model itself doesn't exist we were throwing errors that caused downstream errors. We now warn on this condition and return the model as disabled instead.

Still needs manual testing, leaving in draft for now.

Closes: #96 