### PR TITLE
feat: API endpoint for in-context Supserset dashboards

### DIFF
--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "1.0.2"
+__version__ = "1.1.0"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/extensions/filters.py
+++ b/platform_plugin_aspects/extensions/filters.py
@@ -10,7 +10,11 @@ from django.template import Context, Template
 from openedx_filters import PipelineStep
 from web_fragments.fragment import Fragment
 
-from platform_plugin_aspects.utils import _, generate_superset_context, get_model
+from platform_plugin_aspects.utils import (
+    _,
+    generate_superset_context,
+    get_user_dashboard_locale,
+)
 
 TEMPLATE_ABSOLUTE_PATH = "/instructor_dashboard/"
 BLOCK_CATEGORY = "aspects"
@@ -34,20 +38,7 @@ class AddSupersetTab(PipelineStep):
         show_dashboard_link = settings.SUPERSET_SHOW_INSTRUCTOR_DASHBOARD_LINK
 
         user = get_current_user()
-
-        try:
-            user_language = (
-                get_model("user_preference").get_value(user, "pref-lang") or "en"
-            )
-        # If there is no user_preferences model defined this will get thrown
-        except AttributeError:
-            user_language = "en"
-
-        formatted_language = user_language.lower().replace("-", "_")
-        if formatted_language not in [
-            loc.lower().replace("-", "_") for loc in settings.SUPERSET_DASHBOARD_LOCALES
-        ]:
-            formatted_language = "en"
+        formatted_language = get_user_dashboard_locale(user)
 
         context["course_id"] = course.id
         context = generate_superset_context(

--- a/platform_plugin_aspects/extensions/tests/test_filters.py
+++ b/platform_plugin_aspects/extensions/tests/test_filters.py
@@ -23,10 +23,10 @@ class TestFilters(TestCase):
         self.course_id = "course-v1:org+course+run"
         self.context = {"course": Mock(id=self.course_id), "sections": []}
 
-    @patch("platform_plugin_aspects.extensions.filters.get_model")
-    def test_run_filter_with_language(
+    @patch("platform_plugin_aspects.extensions.filters.get_user_dashboard_locale")
+    def test_run_filter(
         self,
-        mock_get_model,
+        mock_get_user_dashboard_locale,
     ):
         """
         Check the filter is not executed when there are no LimeSurvey blocks in the course.
@@ -34,7 +34,7 @@ class TestFilters(TestCase):
         Expected result:
             - The context is returned without modifications.
         """
-        mock_get_model.return_value.get_value.return_value = "not-a-language"
+        mock_get_user_dashboard_locale.return_value = "en"
 
         context = self.filter.run_filter(self.context, self.template_name)
 
@@ -47,30 +47,4 @@ class TestFilters(TestCase):
             "template_path_prefix": "/instructor_dashboard/",
         }.items() <= context["context"]["sections"][0].items()
 
-        mock_get_model.assert_called_once()
-
-    @patch("platform_plugin_aspects.extensions.filters.get_model")
-    def test_run_filter_without_language(
-        self,
-        mock_get_model,
-    ):
-        """
-        Check the filter is not executed when there are no LimeSurvey blocks in the course.
-
-        Expected result:
-            - The context is returned without modifications.
-        """
-        mock_get_model.return_value.get_value.return_value = None
-
-        context = self.filter.run_filter(self.context, self.template_name)
-
-        assert {
-            "course_id": self.course_id,
-            "section_key": BLOCK_CATEGORY,
-            "section_display_name": "Reports",
-            "superset_url": "http://superset-dummy-url/",
-            "superset_guest_token_url": f"https://lms.url/superset_guest_token/{self.course_id}",
-            "template_path_prefix": "/instructor_dashboard/",
-        }.items() <= context["context"]["sections"][0].items()
-
-        mock_get_model.assert_called_once()
+        mock_get_user_dashboard_locale.assert_called_once()

--- a/platform_plugin_aspects/settings/common.py
+++ b/platform_plugin_aspects/settings/common.py
@@ -104,3 +104,40 @@ def plugin_settings(settings):
             "model": "ObjectTag",
         },
     }
+
+    settings.ASPECTS_IN_CONTEXT_DASHBOARDS = {
+        "course": {
+            "name": _("Course"),
+            "slug": "in-context-course",
+            "uuid": "f2880cc1-63e9-48d7-ac3c-d2ff6f6698e2",
+            "allow_translations": True,
+            "course_filter_ids": ["NATIVE_FILTER-QLQbulmHH"],
+            "block_filter_ids": [],
+        },
+        "sequential": {
+            "name": _("Graded Subsection"),
+            "slug": "in-context-graded-subsection",
+            "uuid": "f0321087-6428-4b97-b32e-2dae7d9cc447",
+            "allow_translations": True,
+            "course_filter_ids": ["NATIVE_FILTER-oPAuR7ahy"],
+            "block_filter_ids": ["NATIVE_FILTER-CBWbI7uLq"],
+        },
+        "problem": {
+            "name": _("Problem"),
+            "slug": "in-context-problem",
+            "uuid": "98ff33ff-18dd-48f9-8c58-629ae4f4194b",
+            "allow_translations": True,
+            "course_filter_ids": ["NATIVE_FILTER-29CPcbirK"],
+            "block_filter_ids": ["NATIVE_FILTER-TJwItQhUI"],
+        },
+        "video": {
+            "name": _("Video"),
+            "slug": "in-context-video",
+            "uuid": "bc6510fb-027f-4026-a333-d0c42d3cc35c",
+            "allow_translations": True,
+            "course_filter_ids": ["NATIVE_FILTER-uaxvZkSAg"],
+            "block_filter_ids": ["NATIVE_FILTER-Fse4rzDW0"],
+        },
+    }
+    settings.IN_CONTEXT_DASHBOARD_COURSE_KEY_COLUMN = "course_key"
+    settings.IN_CONTEXT_DASHBOARD_BLOCK_ID_COLUMN = "block_id"

--- a/platform_plugin_aspects/settings/production.py
+++ b/platform_plugin_aspects/settings/production.py
@@ -28,3 +28,7 @@ def plugin_settings(settings):
         "EVENT_SINK_CLICKHOUSE_PII_MODELS",
         settings.EVENT_SINK_CLICKHOUSE_PII_MODELS,
     )
+    settings.ASPECTS_IN_CONTEXT_DASHBOARDS = settings.ENV_TOKENS.get(
+        "ASPECTS_IN_CONTEXT_DASHBOARDS",
+        settings.ASPECTS_IN_CONTEXT_DASHBOARDS,
+    )

--- a/platform_plugin_aspects/tests/test_utils.py
+++ b/platform_plugin_aspects/tests/test_utils.py
@@ -15,6 +15,7 @@ from platform_plugin_aspects.utils import (
     get_ccx_courses,
     get_model,
     get_tags_for_block,
+    get_user_dashboard_locale,
 )
 from test_utils.helpers import course_factory
 
@@ -271,3 +272,23 @@ class TestUtils(TestCase):
         course_tags = get_tags_for_block(course.location)
         assert course_tags == [1, 2, 3, 4, 5]
         mock_get_object_tags.assert_called_once_with(course.location)
+
+    @patch("platform_plugin_aspects.utils.get_model")
+    def test_get_user_dashboard_locale(self, mock_get_model):
+        """Test that get_user_dashboard_locale gets user language with fallback to 'en'."""
+        mock_get_model.return_value.get_value.return_value = "es-419"
+        user = Mock()
+        assert get_user_dashboard_locale(user) == "es_419"
+        mock_get_model.assert_called_once()
+        mock_get_model.reset_mock()
+
+        mock_get_model.return_value.get_value.return_value = None
+        user = Mock()
+        assert get_user_dashboard_locale(user) == "en"
+        mock_get_model.assert_called_once()
+        mock_get_model.reset_mock()
+
+        mock_get_model.return_value.get_value.return_value = "not-a-language"
+        user = Mock()
+        assert get_user_dashboard_locale(user) == "en"
+        mock_get_model.assert_called_once()

--- a/platform_plugin_aspects/tests/test_views.py
+++ b/platform_plugin_aspects/tests/test_views.py
@@ -29,6 +29,13 @@ class ViewsTestCase(TestCase):
         super().setUp()
         self.client = APIClient()
         self.superset_guest_token_url = f"/superset_guest_token/{COURSE_ID}"
+        self.superset_in_context_dashboard_course_url = (
+            f"/superset_in_context_dashboard/{COURSE_ID}"
+        )
+        self.superset_in_context_dashboard_block_url = (
+            "/superset_in_context_dashboard/"
+            "block-v1:org+course+run+type@problem+block@e25d8eac15224f91bd3aa22bfe28a602"
+        )
         self.user = User.objects.create(
             username="user",
             email="user@example.com",
@@ -54,8 +61,9 @@ class ViewsTestCase(TestCase):
     @patch("platform_plugin_aspects.views.get_model")
     def test_guest_token_course_not_found(self, mock_get_model):
         mock_model_get = Mock(side_effect=ObjectDoesNotExist)
+        mock_model_only = Mock(return_value=Mock(get=mock_model_get))
         mock_get_model.return_value = Mock(
-            objects=Mock(get=mock_model_get),
+            objects=Mock(only=mock_model_only),
             DoesNotExist=ObjectDoesNotExist,
         )
 
@@ -102,8 +110,9 @@ class ViewsTestCase(TestCase):
         mock_has_object_permission.return_value = True
         mock_generate_guest_token.return_value = "test-token"
         mock_model_get = Mock(return_value=Mock(display_name="Course Title"))
+        mock_model_only = Mock(return_value=Mock(get=mock_model_get))
         mock_get_model.return_value = Mock(
-            objects=Mock(get=mock_model_get),
+            objects=Mock(only=mock_model_only),
             DoesNotExist=ObjectDoesNotExist,
         )
 
@@ -117,6 +126,109 @@ class ViewsTestCase(TestCase):
         mock_generate_guest_token.assert_called_once_with(
             user=self.user,
             course=CourseKey.from_string(COURSE_ID),
-            dashboards=settings.ASPECTS_INSTRUCTOR_DASHBOARDS,
+            dashboards=(
+                settings.ASPECTS_INSTRUCTOR_DASHBOARDS
+                + list(settings.ASPECTS_IN_CONTEXT_DASHBOARDS.values())
+            ),
             filters=DEFAULT_FILTERS_FORMAT,
         )
+
+    def test_in_context_dashboard_requires_authorization(self):
+        response = self.client.get(self.superset_in_context_dashboard_course_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_in_context_dashboard_requires_course_access(self):
+        self.client.login(username="user", password="password")
+        response = self.client.get(self.superset_in_context_dashboard_course_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_in_context_dashboard_invalid_usage_key(self):
+        # Will fail as it is not a well-formed block id.
+        superset_in_context_dashboard_course_url = (
+            "/superset_in_context_dashboard/block-v1:org+course+run"
+        )
+        self.client.login(username="user", password="password")
+        response = self.client.get(superset_in_context_dashboard_course_url)
+        self.assertEqual(response.status_code, 404)
+
+    @patch("platform_plugin_aspects.views.get_model")
+    def test_in_context_dashboard_course_not_found(self, mock_get_model):
+        mock_model_get = Mock(side_effect=ObjectDoesNotExist)
+        mock_model_only = Mock(return_value=Mock(get=mock_model_get))
+        mock_get_model.return_value = Mock(
+            objects=Mock(only=mock_model_only),
+            DoesNotExist=ObjectDoesNotExist,
+        )
+
+        self.client.login(username="user", password="password")
+        response = self.client.get(self.superset_in_context_dashboard_course_url)
+        self.assertEqual(response.status_code, 404)
+        mock_model_get.assert_called_once()
+
+    @patch("platform_plugin_aspects.views.get_model")
+    def test_in_context_dashboard_block_course_not_found(self, mock_get_model):
+        mock_model_get = Mock(side_effect=ObjectDoesNotExist)
+        mock_model_only = Mock(return_value=Mock(get=mock_model_get))
+        mock_get_model.return_value = Mock(
+            objects=Mock(only=mock_model_only),
+            DoesNotExist=ObjectDoesNotExist,
+        )
+
+        self.client.login(username="user", password="password")
+        response = self.client.get(self.superset_in_context_dashboard_block_url)
+        self.assertEqual(response.status_code, 404)
+        mock_model_get.assert_called_once()
+
+    @patch.object(IsCourseStaffInstructor, "has_object_permission")
+    def test_in_context_dashboard_block_no_dashboard(self, mock_has_object_permission):
+        mock_has_object_permission.return_value = True
+        # Will be not found as test settings do not include dashboard for video blocks.
+        superset_in_context_dashboard_video_block_url = (
+            "/superset_in_context_dashboard/"
+            "block-v1:org+course+run+type@video+block@e25d8eac15224f91bd3aa22bfe28a602"
+        )
+        self.client.login(username="user", password="password")
+        response = self.client.get(superset_in_context_dashboard_video_block_url)
+        self.assertEqual(response.status_code, 404)
+
+    @patch.object(IsCourseStaffInstructor, "has_object_permission")
+    @patch("platform_plugin_aspects.views.get_localized_uuid")
+    def test_in_context_dashboard_course(
+        self, mock_get_localized_uuid, mock_has_object_permission
+    ):
+        mock_has_object_permission.return_value = True
+        mock_get_localized_uuid.return_value = "00000000-0000-0000-0000-000000000000"
+
+        self.client.login(username="user", password="password")
+        response = self.client.get(self.superset_in_context_dashboard_course_url)
+
+        mock_has_object_permission.assert_called_once()
+
+        dashboard_uuid = settings.ASPECTS_IN_CONTEXT_DASHBOARDS["course"]["uuid"]
+        mock_get_localized_uuid.assert_called_once_with(dashboard_uuid, "en")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["dashboardId"], "00000000-0000-0000-0000-000000000000")
+        self.assertEqual(data["defaultCourseRun"], "run")
+
+    @patch.object(IsCourseStaffInstructor, "has_object_permission")
+    @patch("platform_plugin_aspects.views.get_localized_uuid")
+    def test_in_context_dashboard_block(
+        self, mock_get_localized_uuid, mock_has_object_permission
+    ):
+        mock_has_object_permission.return_value = True
+        mock_get_localized_uuid.return_value = "00000000-0000-0000-0000-000000000000"
+
+        self.client.login(username="user", password="password")
+        response = self.client.get(self.superset_in_context_dashboard_block_url)
+
+        mock_has_object_permission.assert_called_once()
+
+        dashboard_uuid = settings.ASPECTS_IN_CONTEXT_DASHBOARDS["problem"]["uuid"]
+        mock_get_localized_uuid.assert_called_once_with(dashboard_uuid, "en")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["dashboardId"], "00000000-0000-0000-0000-000000000000")
+        self.assertEqual(data["defaultCourseRun"], "run")

--- a/platform_plugin_aspects/urls.py
+++ b/platform_plugin_aspects/urls.py
@@ -8,13 +8,22 @@ from . import views
 
 # Copied from openedx.core.constants
 COURSE_ID_PATTERN = r"(?P<course_id>[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)"
+# Copied from lms.envs.common
+USAGE_ID_PATTERN = (
+    r"(?P<usage_id>(?:i4x://?[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|(?:[^/]+))"
+)
 
 app_url_patterns = (
     [
         re_path(
             rf"superset_guest_token/{COURSE_ID_PATTERN}/?$",
-            views.SupersetView.as_view(),
+            views.SupersetTokenView.as_view(),
             name="superset_guest_token",
+        ),
+        re_path(
+            rf"superset_in_context_dashboard/{USAGE_ID_PATTERN}/?$",
+            views.SupersetInContextDashboardView.as_view(),
+            name="superset_in_context_dashboard",
         ),
     ],
     "platform_plugin_aspects",

--- a/platform_plugin_aspects/utils.py
+++ b/platform_plugin_aspects/utils.py
@@ -37,6 +37,9 @@ DEFAULT_FILTERS_FORMAT = [
 ]
 
 
+DEFAULT_USER_LANGUAGE = "en"
+
+
 def generate_superset_context(
     context,
     dashboards,
@@ -319,17 +322,18 @@ def get_user_dashboard_locale(user):
     """
     try:
         user_language = (
-            get_model("user_preference").get_value(user, "pref-lang") or "en"
+            get_model("user_preference").get_value(user, "pref-lang")
+            or DEFAULT_USER_LANGUAGE
         )
     # If there is no user_preferences model defined this will get thrown
     except AttributeError:
-        user_language = "en"
+        user_language = DEFAULT_USER_LANGUAGE
 
     formatted_language = user_language.lower().replace("-", "_")
     if formatted_language not in [
         loc.lower().replace("-", "_") for loc in settings.SUPERSET_DASHBOARD_LOCALES
     ]:
-        formatted_language = "en"
+        formatted_language = DEFAULT_USER_LANGUAGE
 
     return formatted_language
 

--- a/platform_plugin_aspects/utils.py
+++ b/platform_plugin_aspects/utils.py
@@ -309,3 +309,50 @@ def get_tags_for_block(usage_key) -> set:
             tag = tag.parent
 
     return list(serialized_tags)
+
+
+def get_user_dashboard_locale(user):
+    """
+
+    Get the Superset dashboard locale from the user preference.
+
+    """
+    try:
+        user_language = (
+            get_model("user_preference").get_value(user, "pref-lang") or "en"
+        )
+    # If there is no user_preferences model defined this will get thrown
+    except AttributeError:
+        user_language = "en"
+
+    formatted_language = user_language.lower().replace("-", "_")
+    if formatted_language not in [
+        loc.lower().replace("-", "_") for loc in settings.SUPERSET_DASHBOARD_LOCALES
+    ]:
+        formatted_language = "en"
+
+    return formatted_language
+
+
+def build_filter(filter_id, column, operator, value):
+    """
+
+    Build a Superset native filter option.
+
+    """
+    return {
+        "id": filter_id,
+        "extraFormData": {
+            "filters": [
+                {
+                    "col": column,
+                    "op": operator,
+                    "val": value,
+                },
+            ],
+        },
+        "filterState": {
+            "value": value,
+        },
+        "ownState": {},
+    }

--- a/platform_plugin_aspects/views.py
+++ b/platform_plugin_aspects/views.py
@@ -4,17 +4,26 @@ Endpoints for the Aspects platform plugin.
 
 from collections import namedtuple
 
+import prison
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from rest_framework import permissions
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import APIException, NotFound
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 
-from .utils import DEFAULT_FILTERS_FORMAT, _, generate_guest_token, get_model
+from .utils import (
+    DEFAULT_FILTERS_FORMAT,
+    _,
+    build_filter,
+    generate_guest_token,
+    get_localized_uuid,
+    get_model,
+    get_user_dashboard_locale,
+)
 
 try:
     from openedx.core.lib.api.permissions import (
@@ -58,9 +67,31 @@ except ImportError:
 Course = namedtuple("Course", ["course_id", "display_name"])
 
 
-class SupersetView(GenericAPIView):
+def _get_course(course_key):
     """
-    Superset-related endpoints provided by the aspects platform plugin.
+    Return a Course-like object for the requested course id.
+
+    Raise NotFound if the corresponding course does not exist.
+    """
+    # Fetch the CourseOverview (if we're running in edx-platform)
+    display_name = ""
+    CourseOverview = get_model("course_overviews")
+    if CourseOverview:
+        try:
+            course_overview = CourseOverview.objects.only("display_name").get(
+                id=course_key
+            )
+            display_name = course_overview.display_name
+        except CourseOverview.DoesNotExist as exc:
+            raise NotFound(
+                _("Course not found: '{course_id}'").format(course_id=course_key)
+            ) from exc
+    return Course(course_id=course_key, display_name=display_name)
+
+
+class SupersetTokenView(GenericAPIView):
+    """
+    Superset guest token endpoint.
     """
 
     authentication_classes = (SessionAuthentication,)
@@ -83,19 +114,7 @@ class SupersetView(GenericAPIView):
                 _("Invalid course id: '{course_id}'").format(course_id=course_id)
             ) from exc
 
-        # Fetch the CourseOverview (if we're running in edx-platform)
-        display_name = ""
-        CourseOverview = get_model("course_overviews")
-        if CourseOverview:
-            try:
-                course_overview = CourseOverview.objects.get(id=course_key)
-                display_name = course_overview.display_name
-            except CourseOverview.DoesNotExist as exc:
-                raise NotFound(
-                    _("Course not found: '{course_id}'").format(course_id=course_id)
-                ) from exc
-
-        course = Course(course_id=course_key, display_name=display_name)
+        course = _get_course(course_key)
 
         # May raise a permission denied
         self.check_object_permissions(self.request, course)
@@ -108,7 +127,8 @@ class SupersetView(GenericAPIView):
         """
         course = self.get_object()
 
-        dashboards = settings.ASPECTS_INSTRUCTOR_DASHBOARDS
+        dashboards = settings.ASPECTS_INSTRUCTOR_DASHBOARDS.copy()
+        dashboards.extend(settings.ASPECTS_IN_CONTEXT_DASHBOARDS.values())
         extra_filters_format = settings.SUPERSET_EXTRA_FILTERS_FORMAT
 
         try:
@@ -122,3 +142,102 @@ class SupersetView(GenericAPIView):
             raise APIException() from exc
 
         return Response({"guestToken": guest_token})
+
+
+class SupersetInContextDashboardView(GenericAPIView):
+    """
+    Endpoint for in-context analytics embedded Superset dashboard parameters.
+    """
+
+    authentication_classes = (SessionAuthentication,)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        IsStaffOrReadOnly | IsCourseStaffInstructor,
+    )
+
+    lookup_field = "usage_id"
+
+    def get_object(self):
+        """
+        Return a usage key or course key for the requested usage_key.
+        """
+        usage_id = self.kwargs.get(self.lookup_field, "")
+        try:
+            usage_key = UsageKey.from_string(usage_id)
+        except InvalidKeyError as exc:
+            try:
+                course_key = usage_key = CourseKey.from_string(usage_id)
+            except InvalidKeyError:
+                raise NotFound(
+                    _("Invalid usage id: '{usage_id}'").format(usage_id=usage_id)
+                ) from exc
+        else:
+            course_key = usage_key.course_key
+
+        course = _get_course(course_key)
+        self.check_object_permissions(self.request, course)
+
+        return usage_key
+
+    def get(self, request, *args, **kwargs):
+        """
+        Return Superset context for embedding the dashboard for the requested block.
+        """
+        usage_key = self.get_object()
+        if isinstance(usage_key, CourseKey):
+            block_type = "course"
+            course_key = usage_key
+        else:
+            block_type = usage_key.block_type
+            course_key = usage_key.course_key
+
+        course_key_col = settings.IN_CONTEXT_DASHBOARD_COURSE_KEY_COLUMN
+        block_id_col = settings.IN_CONTEXT_DASHBOARD_BLOCK_ID_COLUMN
+
+        dashboards = settings.ASPECTS_IN_CONTEXT_DASHBOARDS
+        dashboard = dashboards.get(block_type)
+        if dashboard is None:
+            raise NotFound(
+                _("No dashboard for block type: '{block_type}'").format(
+                    block_type=block_type
+                )
+            )
+
+        block_filter = {}
+        if not isinstance(usage_key, CourseKey):
+            for filter_id in dashboard["block_filter_ids"]:
+                block_filter[filter_id] = build_filter(
+                    filter_id, block_id_col, "IN", [usage_key.block_id]
+                )
+
+        course_runs = {}
+        # In the future we might provide other course runs so that the
+        # embedding application can apply their corresponding filters
+        # instead of needing the Superset filter UI.
+        for course_run in [course_key.run]:
+            course_filter = block_filter.copy()
+            for filter_id in dashboard["course_filter_ids"]:
+                course_filter[filter_id] = build_filter(
+                    filter_id, course_key_col, "IN", [str(course_key)]
+                )
+            course_runs[course_run] = {
+                # Superset filter URL parameter is encoded as Rison.
+                "native_filters": prison.dumps(course_filter),
+            }
+
+        if dashboard.get("allow_translations"):
+            language = get_user_dashboard_locale(request.user)
+            dashboard = dashboard.copy()
+            dashboard["uuid"] = get_localized_uuid(dashboard["uuid"], language)
+
+        superset_config = settings.SUPERSET_CONFIG
+        superset_url = superset_config.get("service_url")
+
+        return Response(
+            {
+                "dashboardId": dashboard["uuid"],
+                "supersetUrl": superset_url,
+                "courseRuns": course_runs,
+                "defaultCourseRun": course_key.run,
+            }
+        )

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,3 +16,4 @@ edx-opaque-keys    # Parsing library for course and usage keys
 djangorestframework     # REST API framework
 edx-toggles
 XBlock
+prison             # Rison encoder, same one as used by Superset

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -96,6 +96,8 @@ openedx-filters==2.0.1
     # via -r requirements/base.in
 pbr==6.1.1
     # via stevedore
+prison==0.2.1
+    # via -r requirements/base.in
 prompt-toolkit==3.0.51
     # via click-repl
 psutil==7.0.0
@@ -133,6 +135,7 @@ simplejson==3.20.1
 six==1.17.0
     # via
     #   fs
+    #   prison
     #   python-dateutil
 sqlparse==0.5.3
     # via django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -269,6 +269,8 @@ pluggy==1.5.0
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
+prison==0.2.1
+    # via -r requirements/quality.txt
 prompt-toolkit==3.0.51
     # via
     #   -r requirements/quality.txt
@@ -377,6 +379,7 @@ six==1.17.0
     #   -r requirements/quality.txt
     #   edx-lint
     #   fs
+    #   prison
     #   python-dateutil
 snowballstemmer==2.2.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -194,7 +194,7 @@ model-bakery==1.20.4
     # via
     #   -r requirements/test.txt
     #   django-mock-queries
-more-itertools==10.6.0
+more-itertools==10.7.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -228,6 +228,8 @@ pluggy==1.5.0
     # via
     #   -r requirements/test.txt
     #   pytest
+prison==0.2.1
+    # via -r requirements/test.txt
 prompt-toolkit==3.0.51
     # via
     #   -r requirements/test.txt
@@ -329,6 +331,7 @@ six==1.17.0
     # via
     #   -r requirements/test.txt
     #   fs
+    #   prison
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -200,6 +200,8 @@ pluggy==1.5.0
     # via
     #   -r requirements/test.txt
     #   pytest
+prison==0.2.1
+    # via -r requirements/test.txt
 prompt-toolkit==3.0.51
     # via
     #   -r requirements/test.txt
@@ -290,6 +292,7 @@ six==1.17.0
     #   -r requirements/test.txt
     #   edx-lint
     #   fs
+    #   prison
     #   python-dateutil
 snowballstemmer==2.2.0
     # via pydocstyle

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -159,6 +159,8 @@ pbr==6.1.1
     #   stevedore
 pluggy==1.5.0
     # via pytest
+prison==0.2.1
+    # via -r requirements/base.txt
 prompt-toolkit==3.0.51
     # via
     #   -r requirements/base.txt
@@ -229,6 +231,7 @@ six==1.17.0
     # via
     #   -r requirements/base.txt
     #   fs
+    #   prison
     #   python-dateutil
 sqlparse==0.5.3
     # via

--- a/test_settings.py
+++ b/test_settings.py
@@ -99,6 +99,26 @@ ASPECTS_INSTRUCTOR_DASHBOARDS = [
     }
 ]
 
+ASPECTS_IN_CONTEXT_DASHBOARDS = {
+    "course": {
+        "slug": "in-context-course",
+        "uuid": "f2880cc1-63e9-48d7-ac3c-d2ff6f6698e2",
+        "allow_translations": True,
+        "course_filter_ids": ["NATIVE_FILTER-QLQbulmHH"],
+        "block_filter_ids": [],
+    },
+    "problem": {
+        "slug": "in-context-problem",
+        "uuid": "98ff33ff-18dd-48f9-8c58-629ae4f4194b",
+        "allow_translations": True,
+        "course_filter_ids": ["NATIVE_FILTER-29CPcbirK"],
+        "block_filter_ids": ["NATIVE_FILTER-TJwItQhUI"],
+    },
+}
+
+IN_CONTEXT_DASHBOARD_COURSE_KEY_COLUMN = "course_key"
+IN_CONTEXT_DASHBOARD_BLOCK_ID_COLUMN = "block_id"
+
 EVENT_SINK_CLICKHOUSE_BACKEND_CONFIG = {
     "url": "https://foo.bar",
     "username": "bob",


### PR DESCRIPTION
## Description

Adds an API endpoint for in-context Supserset dashboards.

This uses the dashboards from openedx/tutor-contrib-aspects#1046.

## Supporting information

[In-Context Metrics for Studio: Product Requirements](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4694835220/In-Context+Metrics+for+Studio+Product+Requirements)

## Testing instructions

1. Add this repository checked out to this branch as a Tutor mountpoint: `tutor mounts add platform-plugin-aspects`
2. Install tutor-contrib-aspects from openedx/tutor-contrib-aspects#1046
3. Enable Aspects as instructed in [tutor-contrib-aspects](https://github.com/openedx/tutor-contrib-aspects) (ignoring the pip install tutor-contrib-aspects, as it should be installed from the PR above)
4. Add and enable the following Tutor plugin in order to use the local copy instead of the one installed by tutor-contrib-aspects.
   ```
   from tutor import hooks
     
   hooks.Filters.ENV_PATCHES.add_item(
       (
           "openedx-dev-dockerfile-post-python-requirements",
           """RUN pip install -e /mnt/platform-plugin-aspects"""
       )
   )
   ```
5. Save the following HTML for testing embedding:
   <details>

   ```
   <!DOCTYPE html>
   <html lang="">
     <head>
       <meta charset="utf-8">
       <title></title>
     </head>
     <body>
       <style>
       html, body, div, iframe { width: 100%; height: 100%; }
       </style>
       <script src="https://unpkg.com/@superset-ui/embedded-sdk"></script>
       <div id="my-superset-container"></div>
   
       <script>
         supersetEmbeddedSdk.embedDashboard({
           id: "REPLACE ME",
           supersetDomain: "http://superset.local.openedx.io:8088",
           mountPoint: document.getElementById("my-superset-container"),
           fetchGuestToken: () => "REPLACE ME",
           dashboardUiConfig: {
             hideTitle: true,
             filters: {
               visible: false,
               expanded: false,
             },
             urlParams: {
               native_filters: "REPLACE ME",
             }
           },
           iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox']
         });
       </script>
     </body>
   </html>
   ```

   </details>
6. Obtain the guest token from http://local.openedx.io:8000/aspects/superset_guest_token/course-v1:OpenedX+DemoX+DemoCourse and fill it in the HTML above
7. Obtain the dashboard UUID and native filters from http://local.openedx.io:8000/aspects/superset_in_context_dashboard/course-v1:OpenedX+DemoX+DemoCourse, fill in the HTML above, see that it embeds successfully and loads data corresponsing to the selected course
8. Obtain the dashboard UUID and native filters from http://local.openedx.io:8000/aspects/superset_in_context_dashboard/[block id], fill in the HTML above, see that it embeds successfully and loads data corresponsing to the selected subsection or block

## Deadline

9 April 2025

## Other information

**Merge checklist:**
Check off if complete _or_ not applicable:

- [x] Version bumped
- [ ] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

Private-ref: https://tasks.opencraft.com/browse/BB-9597
