### PR TITLE
feat: add frontendbase instructor dashboard compat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,8 @@ The Instructor Dashboard integration uses the `Open edX Filters`_. To learn more
 the filters, see the `Open edX Filters`_ documentation. Make sure to configure the
 superset pipeline into the filter as follows:
 
+for legacy instructor dashboard:
+
 .. code-block:: python
 
   OPEN_EDX_FILTERS_CONFIG = {
@@ -136,6 +138,19 @@ superset pipeline into the filter as follows:
       "fail_silently": False,
       "pipeline": [
         "platform_plugin_superset.extensions.filters.AddSupersetTab",
+      ]
+    },
+  }
+
+for new instructor dashboard:
+
+.. code-block:: python
+
+  OPEN_EDX_FILTERS_CONFIG = {
+    "org.openedx.learning.instructor.dashboard.tabs.requested.v1": {
+      "fail_silently": False,
+      "pipeline": [
+        "platform_plugin_superset.extensions.filters.AddSupersetTabToInstructorDashboard",
       ]
     },
   }

--- a/platform_plugin_aspects/__init__.py
+++ b/platform_plugin_aspects/__init__.py
@@ -5,6 +5,6 @@ Aspects plugins for edx-platform.
 import os
 from pathlib import Path
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/platform_plugin_aspects/extensions/filters.py
+++ b/platform_plugin_aspects/extensions/filters.py
@@ -84,8 +84,9 @@ class AddSupersetTabToInstructorDashboard(PipelineStep):
     Add superset tab to instructor dashboard app.
     """
 
-    # pylint: disable=arguments-differ, unused-argument
-    def run_filter(self, tabs, user, course_key):
+    def run_filter(
+        self, tabs, user, course_key
+    ):  # pylint: disable=arguments-differ, unused-argument
         """Execute filter that modifies the instructor dashboard context.
         Args:
             tabs (list): the list of tabs for the instructor dashboard.
@@ -97,10 +98,10 @@ class AddSupersetTabToInstructorDashboard(PipelineStep):
         course_id = str(course_key)
 
         custom_tab = {
-            'tab_id': tab_id,
-            'title': _("Reports"),
-            'url': f"/instructor-dashboard/{course_id}/{tab_id}/",
-            'sort_order': 120,
+            "tab_id": tab_id,
+            "title": _("Reports"),
+            "url": f"/instructor-dashboard/{course_id}/{tab_id}/",
+            "sort_order": 120,
         }
 
         modified_tabs.append(custom_tab)

--- a/platform_plugin_aspects/extensions/filters.py
+++ b/platform_plugin_aspects/extensions/filters.py
@@ -84,6 +84,7 @@ class AddSupersetTabToInstructorDashboard(PipelineStep):
     Add superset tab to instructor dashboard app.
     """
 
+    # pylint: disable=arguments-differ, unused-argument
     def run_filter(self, tabs, user, course_key):
         """Execute filter that modifies the instructor dashboard context.
         Args:

--- a/platform_plugin_aspects/extensions/filters.py
+++ b/platform_plugin_aspects/extensions/filters.py
@@ -77,3 +77,30 @@ class AddSupersetTab(PipelineStep):
         )
 
         return data
+
+
+class AddSupersetTabToInstructorDashboard(PipelineStep):
+    """
+    Add superset tab to instructor dashboard app.
+    """
+
+    def run_filter(self, tabs, user, course_key):
+        """Execute filter that modifies the instructor dashboard context.
+        Args:
+            tabs (list): the list of tabs for the instructor dashboard.
+            user (User): the current user.
+            course_key (str): the course key.
+        """
+        modified_tabs = tabs.copy()
+        tab_id = "aspects"
+        course_id = str(course_key)
+
+        custom_tab = {
+            'tab_id': tab_id,
+            'title': _("Reports"),
+            'url': f"/instructor-dashboard/{course_id}/{tab_id}/",
+            'sort_order': 120,
+        }
+
+        modified_tabs.append(custom_tab)
+        return {"tabs": modified_tabs}

--- a/platform_plugin_aspects/extensions/tests/test_filters.py
+++ b/platform_plugin_aspects/extensions/tests/test_filters.py
@@ -6,7 +6,11 @@ from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
-from platform_plugin_aspects.extensions.filters import BLOCK_CATEGORY, AddSupersetTab
+from platform_plugin_aspects.extensions.filters import (
+    BLOCK_CATEGORY,
+    AddSupersetTab,
+    AddSupersetTabToInstructorDashboard,
+)
 
 
 class TestFilters(TestCase):
@@ -48,3 +52,73 @@ class TestFilters(TestCase):
         }.items() <= context["context"]["sections"][0].items()
 
         mock_get_user_dashboard_locale.assert_called_once()
+
+
+class TestAddSupersetTabToInstructorDashboard(TestCase):
+    """
+    Test suite for the AddSupersetTabToInstructorDashboard filter.
+    """
+
+    def setUp(self) -> None:
+        """
+        Set up the test suite.
+        """
+        self.filter = AddSupersetTabToInstructorDashboard(
+            filter_type=Mock(), running_pipeline=Mock()
+        )
+        self.course_key = Mock(__str__=Mock(return_value="course-v1:org+course+run"))
+        self.user = Mock()
+
+    def test_run_filter_appends_aspects_tab(self):
+        """
+        Check that the filter appends the Aspects tab to the existing tabs list.
+
+        Expected result:
+            - The returned tabs list contains the original tabs plus the new aspects tab.
+        """
+        existing_tab = {"tab_id": "existing", "title": "Existing", "sort_order": 10}
+        tabs = [existing_tab]
+
+        result = self.filter.run_filter(
+            tabs=tabs, user=self.user, course_key=self.course_key
+        )
+
+        assert len(result["tabs"]) == 2
+        aspects_tab = result["tabs"][1]
+        assert aspects_tab["tab_id"] == "aspects"
+        assert aspects_tab["title"] == "Reports"
+        assert (
+            aspects_tab["url"]
+            == "/instructor-dashboard/course-v1:org+course+run/aspects/"
+        )
+        assert aspects_tab["sort_order"] == 120
+
+    def test_run_filter_does_not_mutate_original_tabs(self):
+        """
+        Check that the filter does not modify the original tabs list.
+
+        Expected result:
+            - The original tabs list is unchanged after the filter runs.
+        """
+        original_tabs = [{"tab_id": "existing", "title": "Existing", "sort_order": 10}]
+        tabs_copy = original_tabs.copy()
+
+        self.filter.run_filter(
+            tabs=original_tabs, user=self.user, course_key=self.course_key
+        )
+
+        assert original_tabs == tabs_copy
+
+    def test_run_filter_with_empty_tabs(self):
+        """
+        Check that the filter works when the initial tabs list is empty.
+
+        Expected result:
+            - The returned tabs list contains only the aspects tab.
+        """
+        result = self.filter.run_filter(
+            tabs=[], user=self.user, course_key=self.course_key
+        )
+
+        assert len(result["tabs"]) == 1
+        assert result["tabs"][0]["tab_id"] == "aspects"

--- a/platform_plugin_aspects/tests/test_views.py
+++ b/platform_plugin_aspects/tests/test_views.py
@@ -264,7 +264,9 @@ class SupersetInstructorDashboardViewTestCase(TestCase):
 
     def test_invalid_course_id(self):
         self.client.login(username="instructor", password="password")
-        response = self.client.get("/superset_instructor_dashboard/block-v1:org+course+run")
+        response = self.client.get(
+            "/superset_instructor_dashboard/block-v1:org+course+run"
+        )
         self.assertEqual(response.status_code, 404)
 
     @patch("platform_plugin_aspects.views.get_model")
@@ -287,7 +289,13 @@ class SupersetInstructorDashboardViewTestCase(TestCase):
         mock_has_object_permission.return_value = True
         mock_generate_superset_context.return_value = {
             "course_id": COURSE_ID,
-            "superset_dashboards": [{"name": "Course Dashboard", "uuid": "test-uuid", "slug": "course-dashboard"}],
+            "superset_dashboards": [
+                {
+                    "name": "Course Dashboard",
+                    "uuid": "test-uuid",
+                    "slug": "course-dashboard",
+                }
+            ],
             "superset_url": "https://superset.example.com",
             "superset_guest_token_url": f"https://lms.example.com/aspects/superset_guest_token/{COURSE_ID}",
         }

--- a/platform_plugin_aspects/tests/test_views.py
+++ b/platform_plugin_aspects/tests/test_views.py
@@ -232,3 +232,98 @@ class ViewsTestCase(TestCase):
         data = response.json()
         self.assertEqual(data["dashboardId"], "00000000-0000-0000-0000-000000000000")
         self.assertEqual(data["defaultCourseRun"], "run")
+
+
+class SupersetInstructorDashboardViewTestCase(TestCase):
+    """
+    Test cases for SupersetInstructorDashboardView.
+    """
+
+    def setUp(self):
+        """
+        Set up data used by multiple tests.
+        """
+        super().setUp()
+        self.client = APIClient()
+        self.url = f"/superset_instructor_dashboard/{COURSE_ID}"
+        self.user = User.objects.create(
+            username="instructor",
+            email="instructor@example.com",
+        )
+        self.user.set_password("password")
+        self.user.save()
+
+    def test_requires_authorization(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_requires_course_access(self):
+        self.client.login(username="instructor", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_invalid_course_id(self):
+        self.client.login(username="instructor", password="password")
+        response = self.client.get("/superset_instructor_dashboard/block-v1:org+course+run")
+        self.assertEqual(response.status_code, 404)
+
+    @patch("platform_plugin_aspects.views.get_model")
+    def test_course_not_found(self, mock_get_model):
+        mock_model_get = Mock(side_effect=ObjectDoesNotExist)
+        mock_model_only = Mock(return_value=Mock(get=mock_model_get))
+        mock_get_model.return_value = Mock(
+            objects=Mock(only=mock_model_only),
+            DoesNotExist=ObjectDoesNotExist,
+        )
+
+        self.client.login(username="instructor", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 404)
+        mock_model_get.assert_called_once()
+
+    @patch.object(IsCourseStaffInstructor, "has_object_permission")
+    @patch("platform_plugin_aspects.views.generate_superset_context")
+    def test_success(self, mock_generate_superset_context, mock_has_object_permission):
+        mock_has_object_permission.return_value = True
+        mock_generate_superset_context.return_value = {
+            "course_id": COURSE_ID,
+            "superset_dashboards": [{"name": "Course Dashboard", "uuid": "test-uuid", "slug": "course-dashboard"}],
+            "superset_url": "https://superset.example.com",
+            "superset_guest_token_url": f"https://lms.example.com/aspects/superset_guest_token/{COURSE_ID}",
+        }
+
+        self.client.login(username="instructor", password="password")
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("superset_dashboards", data)
+        self.assertIn("superset_url", data)
+        self.assertIn("superset_guest_token_url", data)
+        self.assertIn("show_dashboard_link", data)
+        self.assertEqual(data["superset_url"], "https://superset.example.com")
+        mock_has_object_permission.assert_called_once()
+        mock_generate_superset_context.assert_called_once()
+
+    @patch.object(IsCourseStaffInstructor, "has_object_permission")
+    @patch("platform_plugin_aspects.views.generate_superset_context")
+    def test_show_dashboard_link_from_settings(
+        self, mock_generate_superset_context, mock_has_object_permission
+    ):
+        mock_has_object_permission.return_value = True
+        mock_generate_superset_context.return_value = {
+            "course_id": COURSE_ID,
+            "superset_dashboards": [],
+            "superset_url": "https://superset.example.com",
+            "superset_guest_token_url": f"https://lms.example.com/aspects/superset_guest_token/{COURSE_ID}",
+        }
+
+        self.client.login(username="instructor", password="password")
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(
+            data["show_dashboard_link"],
+            settings.SUPERSET_SHOW_INSTRUCTOR_DASHBOARD_LINK,
+        )

--- a/platform_plugin_aspects/urls.py
+++ b/platform_plugin_aspects/urls.py
@@ -25,6 +25,11 @@ app_url_patterns = (
             views.SupersetInContextDashboardView.as_view(),
             name="superset_in_context_dashboard",
         ),
+        re_path(
+            rf"superset_instructor_dashboard/{COURSE_ID_PATTERN}/?$",
+            views.SupersetInstructorDashboardView.as_view(),
+            name="superset_instructor_dashboard",
+        ),
     ],
     "platform_plugin_aspects",
 )

--- a/platform_plugin_aspects/views.py
+++ b/platform_plugin_aspects/views.py
@@ -20,6 +20,7 @@ from .utils import (
     _,
     build_filter,
     generate_guest_token,
+    generate_superset_context,
     get_localized_uuid,
     get_model,
     get_user_dashboard_locale,
@@ -246,5 +247,65 @@ class SupersetInContextDashboardView(GenericAPIView):
                 "supersetUrl": superset_url,
                 "courseRuns": course_runs,
                 "defaultCourseRun": course_key.run,
+            }
+        )
+
+
+class SupersetInstructorDashboardView(GenericAPIView):
+    """
+    Endpoint for instructor dashboard Superset configuration.
+
+    Returns the Superset context needed by the frontend app to embed
+    the instructor dashboards, including dashboard list, URLs, and
+    display settings.
+    """
+
+    authentication_classes = (SessionAuthentication,)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        IsStaffOrReadOnly | IsCourseStaffInstructor,
+    )
+
+    lookup_field = "course_id"
+
+    def get_object(self):
+        """
+        Return a CourseKey for the requested course_id.
+        """
+        course_id = self.kwargs.get(self.lookup_field, "")
+        try:
+            course_key = CourseKey.from_string(course_id)
+        except InvalidKeyError as exc:
+            raise NotFound(
+                _("Invalid course id: '{course_id}'").format(course_id=course_id)
+            ) from exc
+
+        course = _get_course(course_key)
+
+        # May raise a permission denied
+        self.check_object_permissions(self.request, course)
+
+        return course_key
+
+    def get(self, request, *args, **kwargs):
+        """
+        Return Superset context for embedding the instructor dashboards.
+        """
+        course_key = self.get_object()
+
+        language = get_user_dashboard_locale(request.user)
+        context = {"course_id": str(course_key)}
+        context = generate_superset_context(
+            context,
+            dashboards=settings.ASPECTS_INSTRUCTOR_DASHBOARDS,
+            language=language,
+        )
+
+        return Response(
+            {
+                "superset_dashboards": context["superset_dashboards"],
+                "superset_url": context["superset_url"],
+                "superset_guest_token_url": context["superset_guest_token_url"],
+                "show_dashboard_link": settings.SUPERSET_SHOW_INSTRUCTOR_DASHBOARD_LINK,
             }
         )


### PR DESCRIPTION
In order to have https://github.com/openedx/frontend-app-instructor-dashboard/issues/86 ready we need compatibility for the reports tab.

The old reports tab was being added through a filter that modified the Mako template, the new instructor dashboard it's made with the [frontend-base](https://github.com/openedx/frontend-base) pattern so in order to make the Reports tab available we need some changes

This PR does two things

- creates the class that will be used to run in the pipeline filter for the instructor dashboard tabs
- creates an enpoint that will return the required info to load the superset dahsboards in the frontend-app

This PR depends on:

Implement new filter for the new instructor dashboard data request-> https://github.com/openedx/openedx-filters/pull/355
Uses new filter to modify new tabs endpoint -> https://github.com/openedx/openedx-platform/pull/38499


And will be used in:

Adds the class created here to the pipeline -> https://github.com/openedx/tutor-contrib-aspects/pull/1253
Consumes the endpoint created here -> https://github.com/openedx/frontend-app-aspects

## Test 

- Get the right version of edx-platform -> https://github.com/openedx/openedx-platform/pull/38499
- Setup a the filter to be used:

```py
from tutor import hooks

# Add the pipeline step to the LMS configuration
hooks.Filters.ENV_PATCHES.add_item(
    (
        "openedx-lms-common-settings",
        """

# Register the filter configuration
if "OPEN_EDX_FILTERS_CONFIG" not in locals():
    OPEN_EDX_FILTERS_CONFIG = {}

OPEN_EDX_FILTERS_CONFIG.update({
    "org.openedx.learning.instructor.dashboard.tabs.requested.v1": {
        "pipeline": [
            "platform_plugin_aspects.extensions.filters.AddSupersetTabToInstructorDashboard",
        ],
        "fail_silently": False,
    },
})
""",
    )
)
```

And test the request, you should be able to see inside the tabs object a new tab for aspects

```bash
curl 'http://local.openedx.io:8000/api/instructor/v2/courses/course-v1:OpenedX+DemoX+DemoCourse' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en,es-419;q=0.9,es;q=0.8' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Origin: http://apps.local.openedx.io:8080' \
  -H 'Pragma: no-cache' \
  -H 'Referer: http://apps.local.openedx.io:8080/' \
  -H 'USE-JWT-COOKIE: true' \
  -H 'User-Agent: Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Mobile Safari/537.36' \
  --insecure
```

This is an example of the request but it's missing the cookies etc... tailor it to be able to run in your scenario

**Merge checklist:**
Check off if complete _or_ not applicable:

- [x] Version bumped
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
