### PR TITLE
chore: Restrict pip version to less than 26.2

### DIFF
--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,6 +1,6 @@
 # Core dependencies for installing other packages
 -c constraints.txt
 
-pip
+pip<26.2
 setuptools
 wheel


### PR DESCRIPTION
incompatible with pip-tools 7.6.0

**Merge checklist:**
Check off if complete _or_ not applicable:

- [ ] Version bumped
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
